### PR TITLE
Fixed compiling problems due to _XOPEN_SOURCE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -std=c99 -g -Wall -Wextra
+CFLAGS = -std=c99 -g -Wall -Wextra -Werror
 OBJS = src/kheadgen.o
 BIN = bin/kheadgen
 RM = rm -rv

--- a/src/kheadgen.c
+++ b/src/kheadgen.c
@@ -7,14 +7,14 @@
  * ----------------------------------------------------------------------------
  */
 
+#ifdef __linux__
+# define _XOPEN_SOURCE 700
+#endif /* !__linux__ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <libgen.h>
-
-#ifndef __APPLE__
-# define _XOPEN_SOURCE 700
-#endif /* !__APPLE__ */
 
 static char *create_def_name(char *name)
 {


### PR DESCRIPTION
**Makefile**

I added the _CFLAGS_ variable in order to add -Werror and allow the project to compile without any errors and warnings.

**Definition of _XOPEN_SOURCE**

I changed the position of this definition in order to allow Linux users to compile the project properly without warnings. I based the new definition on the fact that the platform is Linux.
